### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Stale Branches
         uses: crs-k/stale-branches@v7.0.0
-      - uses: actions/stale@v5
+      - uses: actions/stale@v9.1.0
         with:
           repo-token: ${{ github.token }} # secrets.GITHUB_TOKEN
           stale-issue-message: 'Stale issue message'
@@ -43,7 +43,7 @@ jobs:
           WORKFLOW_SECRET: op://${{ secrets.OP_VAULT }}/gh-workflow/credential
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ steps.opw.outputs.WORKFLOW_SECRET }}
@@ -61,7 +61,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5.0.0
       with:
         repo-token: "${{ github.token }}"
 

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -15,27 +15,27 @@ jobs:
       previous: ${{ steps.version.outputs.previous-version }} 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.head_ref }}   # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
         id: version
-        uses: codacy/git-version@2.7.1
+        uses: codacy/git-version@2.8.0
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         name: install rust toolchain
         with:
           toolchain: nightly
           override: true
 
-      - uses: actions-rs/grcov@v0.1
+      - uses: actions-rs/grcov@v0.1.5
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
@@ -53,7 +53,7 @@ jobs:
           CODECOV_TOKEN: op://${{ env.OPW_VAULT }}/codecov/api_token
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v5.4.0
         with:
           token: ${{ env.CODECOV_TOKEN }}
 
@@ -66,7 +66,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: code-coverage-report
           path: cobertura.xml
@@ -74,20 +74,20 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         name: install rust toolchain
         with:
           toolchain: nightly
           override: true
 
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         name: run cargo fmt
         with:
           command: fmt
 
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         name: run cargo clippy
         with:
           command: clippy
@@ -95,20 +95,20 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         name: install rust toolchain
         with:
           toolchain: nightly
           override: true
 
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         name: run cargo fmt
         with:
           command: fmt
 
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         with:
           command: test
           args: --all-features --no-fail-fast
@@ -120,15 +120,15 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         name: install rust toolchain
         with:
           toolchain: nightly
           override: true
 
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         name: run cargo doc
         with:
           command: doc
@@ -136,15 +136,15 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         name: install rust toolchain
         with:
           toolchain: nightly
           override: true
 
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         name: run cargo bench
         with:
           command: bench
@@ -157,7 +157,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Load secret
         uses: 1password/load-secrets-action@v2
@@ -169,23 +169,23 @@ jobs:
           SNYK_TOKEN: op://${{ env.OPW_VAULT }}/snyk/key_name
           GITGUARDIAN_API_KEY: op://${{ env.OPW_VAULT }}/gitguardian/key_name
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         name: install rust toolchain
         with:
           toolchain: nightly
           override: true
 
-      - uses: actions-rs/audit-check@v1
+      - uses: actions-rs/audit-check@v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.88.16
+        uses: trufflesecurity/trufflehog@v3.88.17
 
       # - name: Snyk
       #   uses: snyk/actions@0.4.0
 
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v2.3.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       dockerfile: ${{ steps.dockerfile.outputs.files_exists }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Check for Dockerfile 
         id: dockerfile
@@ -34,14 +34,14 @@ jobs:
       previous: ${{ steps.version.outputs.previous-version }} 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.head_ref }}   # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
         id: version
-        uses: codacy/git-version@2.7.1
+        uses: codacy/git-version@2.8.0
 
   docker:
     runs-on: ubuntu-latest
@@ -58,30 +58,30 @@ jobs:
           DOCKERHUB_TOKEN: op://${{ env.OPW_VAULT }}/docker/api_token
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.4.0
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.10.0
 
       - name: Validate build configuration
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.15.0
         with:
           call: check
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.7.0
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.15.0
         with:
           load: true
           tags: ${{ needs.semver.outputs.current }}
@@ -92,7 +92,7 @@ jobs:
           docker run --rm ${{ needs.semver.outputs.current }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.15.0
         with:
           provenance: mode=max
           file: ${{ env.DOCKERFILE }}
@@ -117,7 +117,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Release Drafter
         uses: release-drafter/release-drafter@v6.1.0
         env:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gitleaks/gitleaks-action](https://github.com/gitleaks/gitleaks-action)** published a new release **[v2.3.7](https://github.com/gitleaks/gitleaks-action/releases/tag/v2.3.7)** on 2024-10-13T12:26:47Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.6.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.6.0)** on 2025-02-28T12:55:32Z
* **[actions-rs/cargo](https://github.com/actions-rs/cargo)** published a new release **[v1.0.1](https://github.com/actions-rs/cargo/releases/tag/v1.0.1)** on 2019-09-15T09:21:00Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.15.0](https://github.com/docker/build-push-action/releases/tag/v6.15.0)** on 2025-02-26T15:28:00Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.7.0](https://github.com/docker/metadata-action/releases/tag/v5.7.0)** on 2025-02-26T15:31:35Z
* **[actions/labeler](https://github.com/actions/labeler)** published a new release **[v5.0.0](https://github.com/actions/labeler/releases/tag/v5.0.0)** on 2023-12-04T14:14:37Z
* **[actions-rs/grcov](https://github.com/actions-rs/grcov)** published a new release **[v0.1.5](https://github.com/actions-rs/grcov/releases/tag/v0.1.5)** on 2020-02-05T20:35:41Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.10.0)** on 2025-02-26T15:36:31Z
* **[actions-rs/audit-check](https://github.com/actions-rs/audit-check)** published a new release **[v1.2.0](https://github.com/actions-rs/audit-check/releases/tag/v1.2.0)** on 2020-05-07T08:21:51Z
* **[actions-rs/toolchain](https://github.com/actions-rs/toolchain)** published a new release **[v1.0.6](https://github.com/actions-rs/toolchain/releases/tag/v1.0.6)** on 2020-03-24T13:30:11Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.1](https://github.com/actions/upload-artifact/releases/tag/v4.6.1)** on 2025-02-21T19:00:26Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)** on 2025-03-14T09:53:25Z
* **[trufflesecurity/trufflehog](https://github.com/trufflesecurity/trufflehog)** published a new release **[v3.88.17](https://github.com/trufflesecurity/trufflehog/releases/tag/v3.88.17)** on 2025-03-13T17:43:15Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.4.0](https://github.com/codecov/codecov-action/releases/tag/v5.4.0)** on 2025-02-26T23:41:16Z
* **[codacy/git-version](https://github.com/codacy/git-version)** published a new release **[2.8.0](https://github.com/codacy/git-version/releases/tag/2.8.0)** on 2022-11-22T16:08:38Z
* **[actions/stale](https://github.com/actions/stale)** published a new release **[v9.1.0](https://github.com/actions/stale/releases/tag/v9.1.0)** on 2025-01-21T03:34:36Z
